### PR TITLE
Add combobox to view/set display group of objects

### DIFF
--- a/ServiceManager/GUI/config_entry.py
+++ b/ServiceManager/GUI/config_entry.py
@@ -56,6 +56,8 @@ class UIConfigEntryDialog(QDialog):
         self.object_name_filter.focusOut.connect(self.load_object_data)  # connect filter custom signal to slot
         self.obj_name_cb.installEventFilter(self.object_name_filter)  # install filter to widget
 
+        self.obj_display_group_cb.currentTextChanged.connect(self.message_lbl.clear)
+
         self.obj_type_cb.currentTextChanged.connect(self.message_lbl.clear)
         self.obj_type_cb.currentTextChanged.connect(lambda: set_red_border(self.obj_type_frame, False))
         self.obj_type_cb.currentTextChanged.connect(self.update_measurement_types)
@@ -116,6 +118,13 @@ class UIConfigEntryDialog(QDialog):
         self.obj_type_cb.addItem(None)
         try:
             self.obj_type_cb.addItems(get_all_type_names())
+        except TypeError:
+            pass
+
+        self.obj_display_group_cb.clear()
+        self.obj_display_group_cb.addItem(None)
+        try:
+            self.obj_display_group_cb.addItems(get_all_display_names())
         except TypeError:
             pass
 
@@ -317,6 +326,7 @@ class UIConfigEntryDialog(QDialog):
         """
         if self.type_and_comment_updated:
             self.obj_type_cb.setCurrentIndex(0)
+            self.obj_display_group_cb.setCurrentIndex(0)
             self.obj_comment.clear()
             self.type_and_comment_updated = False
 
@@ -344,6 +354,7 @@ class UIConfigEntryDialog(QDialog):
         self.message_lbl.clear()
 
         obj_id = get_object_id(current_object_name) if current_object_name else False
+        self.obj_display_group_cb.setEnabled(not obj_id)
         self.obj_type_cb.setEnabled(not obj_id)
         self.obj_comment.setEnabled(not obj_id)
         if not obj_id:
@@ -363,9 +374,11 @@ class UIConfigEntryDialog(QDialog):
         obj_record = get_object(obj_id)
         obj_class_name = get_object_class(object_id=obj_id)
         type_name = get_object_type(object_id=obj_id)
+        display_name = get_object_display_group(obj_id)
 
         self.obj_comment.setText(obj_record.ob_comment if obj_record else None)
         self.obj_type_cb.setCurrentText(type_name)
+        self.obj_display_group_cb.setCurrentText(display_name)
         self.type_and_comment_updated = True
 
         self.obj_detail_name.setText(get_object_name(obj_id))

--- a/ServiceManager/GUI/config_entry.py
+++ b/ServiceManager/GUI/config_entry.py
@@ -177,7 +177,7 @@ class UIConfigEntryDialog(QDialog):
         if not object_id:
             type_name = self.obj_type_cb.currentText()
             type_id = get_type_id(type_name=type_name)
-
+            display_group_id = get_display_group_id(display_group=self.obj_display_group_cb.currentText())
             msg_box = QMessageBox.question(self, 'Create new object',
                                            f'Create new object "{object_name}" with type "{type_name}" '
                                            f'and save the PV configuration?',
@@ -186,7 +186,7 @@ class UIConfigEntryDialog(QDialog):
                 return
 
             try:
-                object_id = add_object(object_name, type_id, self.obj_comment.text())
+                object_id = add_object(object_name, type_id, display_group_id, self.obj_comment.text())
             except DBObjectNameAlreadyExists:
                 self.set_message_colored_text(f'Object "{object_name}" already exists in the database.', 'red')
                 set_red_border(self.obj_name_frame)

--- a/ServiceManager/GUI/layouts/ConfigEntry.ui
+++ b/ServiceManager/GUI/layouts/ConfigEntry.ui
@@ -428,11 +428,11 @@
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>
             <layout class="QGridLayout" name="gridLayout">
-             <item row="2" column="1" colspan="4">
-              <widget class="QLineEdit" name="obj_detail_func">
+             <item row="0" column="4">
+              <widget class="QLineEdit" name="obj_detail_id">
                <property name="maximumSize">
                 <size>
-                 <width>16777215</width>
+                 <width>50</width>
                  <height>16777215</height>
                 </size>
                </property>
@@ -444,11 +444,8 @@
                <property name="focusPolicy">
                 <enum>Qt::NoFocus</enum>
                </property>
-               <property name="toolTip">
-                <string>The function of the object.</string>
-               </property>
                <property name="whatsThis">
-                <string>The object's function, describing the overall purpose of the device.</string>
+                <string>The database record ID of the object.</string>
                </property>
                <property name="styleSheet">
                 <string notr="true">background-color: #F0F0F0;</string>
@@ -481,22 +478,6 @@
                 <set>Qt::AlignCenter</set>
                </property>
               </widget>
-             </item>
-             <item row="0" column="2">
-              <spacer name="horizontalSpacer_15">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Fixed</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>5</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
              </item>
              <item row="0" column="0">
               <widget class="QLabel" name="obj_detail_name_lbl">
@@ -535,11 +516,27 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="4">
-              <widget class="QLineEdit" name="obj_detail_id">
+             <item row="0" column="2">
+              <spacer name="horizontalSpacer_15">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Fixed</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>5</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="2" column="1" colspan="4">
+              <widget class="QLineEdit" name="obj_detail_func">
                <property name="maximumSize">
                 <size>
-                 <width>50</width>
+                 <width>16777215</width>
                  <height>16777215</height>
                 </size>
                </property>
@@ -551,8 +548,11 @@
                <property name="focusPolicy">
                 <enum>Qt::NoFocus</enum>
                </property>
+               <property name="toolTip">
+                <string>The function of the object.</string>
+               </property>
                <property name="whatsThis">
-                <string>The database record ID of the object.</string>
+                <string>The object's function, describing the overall purpose of the device.</string>
                </property>
                <property name="styleSheet">
                 <string notr="true">background-color: #F0F0F0;</string>
@@ -649,6 +649,16 @@
                </property>
                <property name="alignment">
                 <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1" colspan="4">
+              <widget class="QComboBox" name="obj_display_group_cb"/>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="label">
+               <property name="text">
+                <string>Display Group</string>
                </property>
               </widget>
              </item>

--- a/ServiceManager/db_func.py
+++ b/ServiceManager/db_func.py
@@ -110,6 +110,21 @@ def get_type_id(type_name: str):
 
 
 @need_connection
+def get_display_group_id(display_group: str):
+    """
+    Get the ID of the object type with the given name.
+
+    Args:
+        display_group (str): The display group name.
+
+    Returns:
+        type_id (int/None): The object type ID, None if not found.
+    """
+    group = GamDisplaygroup.get_or_none(GamDisplaygroup.dg_name == display_group)
+    return group.dg_id if group else None
+
+
+@need_connection
 def get_object_type(object_id: int):
     """
     Returns the type name of the object with the specified ID.
@@ -219,7 +234,7 @@ def get_object_display_group(object_id: int):
     try:
         display_id = obj.ob_displaygroup
         return display_id.dg_name
-    except DoesNotExist:
+    except (DoesNotExist, AttributeError):
         return
 
 
@@ -232,13 +247,14 @@ def create_sld_if_required(object_id: int, object_name: str, type_name: str, cla
 
 
 @need_connection
-def add_object(name: str, type_id: int, comment: str = None):
+def add_object(name: str, type_id: int, display_group_id: int = None, comment: str = None):
     """
     Create a new object with the given name, type and comment.
 
     Args:
         name (str): The name of the object.
         type_id (int): The type ID of the object.
+        display_group_id (int): The ID of the display group this object is part of.
         comment (str): Object comment.
 
     Returns:
@@ -251,7 +267,8 @@ def add_object(name: str, type_id: int, comment: str = None):
         raise DBObjectNameAlreadyExists(f'Could not create object - '
                                         f'Object with name "{name}" already exists in the database.')
 
-    record_id = GamObject.insert(ob_name=name, ob_objecttype=type_id, ob_comment=comment).execute()
+    record_id = GamObject.insert(ob_name=name, ob_objecttype=type_id, ob_displaygroup=display_group_id,
+                                 ob_comment=comment).execute()
 
     logger.info(f'Created object no. {record_id} ("{name}") of type {type_id}.')
 

--- a/ServiceManager/db_func.py
+++ b/ServiceManager/db_func.py
@@ -83,6 +83,18 @@ def get_all_type_names():
 
 
 @need_connection
+def get_all_display_names():
+    """
+    Get a list of all display group names.
+
+    Returns:
+        (list): The display group names.
+    """
+    query = GamDisplaygroup.select(GamDisplaygroup.dg_name)
+    return [x.dg_name for x in query if x]
+
+
+@need_connection
 def get_type_id(type_name: str):
     """
     Get the ID of the object type with the given name.
@@ -190,6 +202,25 @@ def get_object_sld(object_id: int):
     sld_id = get_sld_id(object_id)
     sld = GamObject.get_or_none(GamObject.ob_id == sld_id)
     return sld.ob_name if sld else None
+
+
+@need_connection
+def get_object_display_group(object_id: int):
+    """
+    Get the name of the object's display group if it has one.
+
+    Args:
+        object_id (int): The object ID.
+
+    Returns:
+        (str/None): The object's display group, None if not found.
+    """
+    obj = GamObject.get_or_none(GamObject.ob_id == object_id)
+    try:
+        display_id = obj.ob_displaygroup
+        return display_id.dg_name
+    except DoesNotExist:
+        return
 
 
 @need_connection


### PR DESCRIPTION
### Description of work
Added Combobox to gui that when an existing object is selected is locked and displays that objects display group. If a new object is being created combobox is unlocked and can be used to select a display group.

### Ticket
#5 

### Acceptance criteria
- The Object PV Configuration GUI should have a combobox labelled "Display Group"
- When an existing object is selected the combobox should be disabled, and display the objects display group.
- When creating a new object the user should be able to select a display group.
- Saving a new object with the display group set should lead to the objects being properly set.

### Requirements
#14 must be merged before this is.
