### PR TITLE
Added length check and SQL logging to config entry

### DIFF
--- a/ServiceManager/GUI/config_entry.py
+++ b/ServiceManager/GUI/config_entry.py
@@ -178,6 +178,8 @@ class UIConfigEntryDialog(QDialog):
 
             try:
                 object_id = add_object(object_name, type_id, self.obj_comment.text())
+                create_sld_if_required(object_id=object_id, object_name=object_name,
+                                       type_name=type_name, class_id=get_class_id(type_id))
             except DBObjectNameAlreadyExists:
                 self.set_message_colored_text(f'Object "{object_name}" already exists in the database.', 'red')
                 set_red_border(self.obj_name_frame)
@@ -186,9 +188,6 @@ class UIConfigEntryDialog(QDialog):
                 manager_logger.error(f'Exception occurred when adding new object to DB, aborting PV Config entry '
                                      f'creation: {e}')
                 return
-
-            create_sld_if_required(object_id=object_id, object_name=object_name,
-                                   type_name=type_name, class_id=get_class_id(type_id))
 
         # Check if object already has a PV configuration (worth checking even for objects not in the DB)
         existing_ids = Settings.Service.PVConfig.get_entry_object_ids()

--- a/ServiceManager/GUI/config_entry.py
+++ b/ServiceManager/GUI/config_entry.py
@@ -259,10 +259,8 @@ class UIConfigEntryDialog(QDialog):
             return False
 
         input_valid = True
+        check_length = 50
         self.message_lbl.clear()
-        # if no object name
-        if not self.obj_name_cb.lineEdit().text():
-            input_valid = _set_invalid('Object name is required.', self.obj_name_frame)
         # if no object type
         type_name = self.obj_type_cb.currentText()
         if not type_name:
@@ -271,6 +269,21 @@ class UIConfigEntryDialog(QDialog):
             type_id = get_type_id(type_name=type_name)
             if not type_id:
                 input_valid = _set_invalid(f'Type "{type_name}" was not found.', self.obj_type_frame)
+            else:
+                # if type is valid check if it's one that requires SLD
+                if type_id == 2 or type_id == 4 or type_id == 7:
+                    logger.info(type_id)
+                    logger.info(get_max_object_id())
+                    # remove length of SLD "" (ID: <id>)
+                    check_length -= len(str(get_max_object_id()+1))+13
+        # if no object name
+        if not self.obj_name_cb.lineEdit().text():
+            input_valid = _set_invalid('Object name is required.', self.obj_name_frame)
+        else:
+            if len(self.obj_name_cb.lineEdit().text()) > check_length:
+                input_valid = \
+                    _set_invalid('Object name is too long. Max length for this object is: {}'.format(check_length),
+                                 self.obj_name_frame)
 
         # if no mea pv names
         if not any(mea[0].text() for mea in self.mea_widgets):

--- a/ServiceManager/GUI/config_entry.py
+++ b/ServiceManager/GUI/config_entry.py
@@ -272,10 +272,8 @@ class UIConfigEntryDialog(QDialog):
             else:
                 # if type is valid check if it's one that requires SLD
                 if type_id == 2 or type_id == 4 or type_id == 7:
-                    logger.info(type_id)
-                    logger.info(get_max_object_id())
-                    # remove length of SLD "" (ID: <id>)
-                    check_length -= len(str(get_max_object_id()+1))+13
+                    # remove length of SLD "" (ID: <id>) as this is added to the name of the objects SLD
+                    check_length -= len('SLD "" (ID: {})'.format(get_max_object_id()+1))
         # if no object name
         if not self.obj_name_cb.lineEdit().text():
             input_valid = _set_invalid('Object name is required.', self.obj_name_frame)

--- a/ServiceManager/GUI/config_entry.py
+++ b/ServiceManager/GUI/config_entry.py
@@ -258,9 +258,10 @@ class UIConfigEntryDialog(QDialog):
             return False
 
         input_valid = True
-        check_length = 50
+        object_name_max_length = 50
         self.message_lbl.clear()
-        # if no object type
+
+        # check object type
         type_name = self.obj_type_cb.currentText()
         if not type_name:
             input_valid = _set_invalid('Object type is required.', self.obj_type_frame)
@@ -269,20 +270,20 @@ class UIConfigEntryDialog(QDialog):
             if not type_id:
                 input_valid = _set_invalid(f'Type "{type_name}" was not found.', self.obj_type_frame)
             else:
-                # if type is valid check if it's one that requires SLD
-                if type_id == 2 or type_id == 4 or type_id == 7:
-                    # remove length of SLD "" (ID: <id>) as this is added to the name of the objects SLD
-                    check_length -= len('SLD "" (ID: {})'.format(get_max_object_id()+1))
-        # if no object name
+                class_id = get_class_id(type_id=type_id)
+                if class_id in [DBClassIDs.VESSEL, DBClassIDs.CRYOSTAT, DBClassIDs.GAS_COUNTER]:
+                    # if object will have an SLD, lower max name length to make space for the SLD object name formatting
+                    object_name_max_length -= len(generate_sld_name(object_name="", object_id=get_max_object_id() + 1))
+
+        # check object name
         if not self.obj_name_cb.lineEdit().text():
             input_valid = _set_invalid('Object name is required.', self.obj_name_frame)
         else:
-            if len(self.obj_name_cb.lineEdit().text()) > check_length:
-                input_valid = \
-                    _set_invalid('Object name is too long. Max length for this object is: {}'.format(check_length),
-                                 self.obj_name_frame)
+            if len(self.obj_name_cb.lineEdit().text()) > object_name_max_length:
+                input_valid = _set_invalid('Object name is too long. Max length for this object is: {}'
+                                           .format(object_name_max_length), self.obj_name_frame)
 
-        # if no mea pv names
+        # check measurement pv names
         if not any(mea[0].text() for mea in self.mea_widgets):
             input_valid = _set_invalid('At least one measurement is required.', self.mea_pvs_frame)
 

--- a/ServiceManager/db_func.py
+++ b/ServiceManager/db_func.py
@@ -1,6 +1,7 @@
 from peewee import DoesNotExist
 from datetime import datetime
 
+from ServiceManager.utilities import generate_sld_name
 from shared.const import DBTypeIDs, DBClassIDs
 from shared.utils import get_sld_id, need_connection
 from shared.db_models import *
@@ -210,7 +211,7 @@ def get_object_sld(object_id: int):
 @need_connection
 def create_sld_if_required(object_id: int, object_name: str, type_name: str, class_id: int):
     if class_id in [DBClassIDs.VESSEL, DBClassIDs.CRYOSTAT, DBClassIDs.GAS_COUNTER]:
-        sld_id = add_object(name=f'SLD "{object_name}" (ID: {object_id})', type_id=DBTypeIDs.SLD,
+        sld_id = add_object(name=generate_sld_name(object_name, object_id), type_id=DBTypeIDs.SLD,
                             comment=f'Software Level Device for {type_name} "{object_name}" (ID: {object_id})')
         add_relation(or_object_id=object_id, or_object_id_assigned=sld_id)
 

--- a/ServiceManager/db_func.py
+++ b/ServiceManager/db_func.py
@@ -44,6 +44,21 @@ def get_object_id(object_name):
 
 
 @need_connection
+def get_max_object_id():
+    """
+    Get the ID highest ID.
+
+    Returns:
+        (int): The highest object ID in the database or zero if there isn't any present.
+    """
+    query = GamObject.select(GamObject.ob_id).order_by(GamObject.ob_id)
+    if not query:
+        return 0
+    else:
+        return query[-1].ob_id
+
+
+@need_connection
 def get_object_name(object_id):
     """
     Gets the name of the object with the given ID.

--- a/ServiceManager/utilities.py
+++ b/ServiceManager/utilities.py
@@ -117,3 +117,7 @@ def setup_button(button: QPushButton, icon_name: str = None):
         button.setIcon(QIcon(os.path.join(ASSETS_PATH, icon_name)))
     button.setIconSize(QSize(15, 15))
     button.setStyleSheet("QPushButton { text-align: left; }")
+
+
+def generate_sld_name(object_name: str, object_id: int):
+    return f'SLD "{object_name}" (ID: {object_id})'


### PR DESCRIPTION
### Description of work
- Attempting to add too long a name (taking into account whether an SLD is needed, and if so, the ID number) now causes a warning and does not add to the databse. The name field is highlighted red when this is the case.
- Failing to create an SLD is now logged at the same level as failing to create any other object.

### Ticket
#16 
#6

### Acceptance criteria
- Attempting to add too long a name (<50 chars) leads to a warning that the name is too long with the name field highlighted.
- Attempting to add an object that would require an SLD leads the check to be <37 - the length of the id number of the object chars.
- If create_sld_if_required is somehow called but fails, an it is logged the same way as if create_object fails.
- #14 Must be merged before this ticket.