### PR TITLE
Add Mercury Cryostat PVs (Non-PLC)

### DIFF
--- a/HLM_PV_Import/ca_wrapper.py
+++ b/HLM_PV_Import/ca_wrapper.py
@@ -140,4 +140,4 @@ class PvMonitors:
         Returns:
             (int): Time in seconds since last update
         """
-        return self._pv_last_update[pv_name] - time.time()
+        return time.time() - self._pv_last_update[pv_name]

--- a/HLM_PV_Import/db_func.py
+++ b/HLM_PV_Import/db_func.py
@@ -111,3 +111,24 @@ def add_measurement(object_id, mea_values: dict):
     logger.info(f'Added measurement {record_id} for {obj.ob_name} ({object_id}) with values: {dict(mea_values)}')
     # noinspection PyProtectedMember
     db_logger.info(f"Added record no. {record_id} to {GamMeasurement._meta.table_name}")
+
+
+def get_obj_id_and_create_if_not_exist(obj_name: str, type_id: int, comment: str):
+    """
+    Get the ID of the object with the given name. Create one if it doesn't exist.
+
+    Args:
+        obj_name (str): The object name.
+        type_id (int): The object's type ID.
+        comment (str): Object comment.
+
+    Returns:
+        (int): The object ID.
+    """
+    obj_id = GamObject.select(GamObject.ob_id).where(GamObject.ob_name == obj_name).first()
+    if obj_id is None:
+        added_obj_id = GamObject.insert(ob_name=obj_name, ob_objecttype=type_id, ob_comment=comment).execute()
+        db_logger.info(f'Created object no. {added_obj_id} ("{obj_name}") of type {type_id}.')
+        return added_obj_id
+    else:
+        return obj_id

--- a/HLM_PV_Import/external_pvs.py
+++ b/HLM_PV_Import/external_pvs.py
@@ -1,0 +1,35 @@
+""" PVs that are not part of the Helium Recovery PLC """
+from HLM_PV_Import.ca_wrapper import get_instrument_list
+from HLM_PV_Import.settings import DBTypeIDs
+
+
+class MercuryPVs:
+    def __init__(self):
+        self.full_inst_list = get_instrument_list()
+
+        self.instruments = [x['name'] for x in self.full_inst_list]
+        self.ignored_instruments = ['DEMO', 'DETMON', 'RIKENFE', 'MUONFE', 'ENGINX', 'INES', 'NIMROD', 'SANDALS',
+                                    'IMAT', 'ALF', 'CRISP', 'INTER', 'LOQ', 'SURF', 'TOSCA', 'VESUVIO']
+        # Add _SETUP instruments to ignored
+        self.ignored_instruments.extend([x['name'] for x in self.full_inst_list if '_SETUP' in x['name']])
+        self.IOCs = ['MERCURY_01', 'MERCURY_02']
+        self.PVs = ['LEVEL:1:HELIUM']  # max 5
+
+        self.inst_to_check = list(set(self.instruments) ^ set(self.ignored_instruments))
+        self.prefixes = {x['name']: x['pvPrefix'] for x in self.full_inst_list if x['name'] in self.inst_to_check}
+
+        self.pv_config = self._get_config()
+
+        self.name = 'Mercury Cryostat Controllers'
+        self.objects_type = DBTypeIDs.MERCURY_CRYOSTAT
+
+    def _get_config(self):
+        pv_config = {}
+        for name, prefix in self.prefixes.items():
+            for ioc in self.IOCs:
+                obj_name = f'{name} {ioc}'
+                pv_config[obj_name] = [f'{prefix}{ioc}:{pv}' for pv in self.PVs]
+        return pv_config
+
+    def get_full_pv_list(self):
+        return [f'{prefix}{ioc}:{pv}' for prefix in self.prefixes.values() for ioc in self.IOCs for pv in self.PVs]

--- a/HLM_PV_Import/pv_import.py
+++ b/HLM_PV_Import/pv_import.py
@@ -1,25 +1,29 @@
 from HLM_PV_Import.ca_wrapper import PvMonitors
 from HLM_PV_Import.user_config import UserConfig
 from HLM_PV_Import.settings import PvImportConfig
-from HLM_PV_Import.logger import logger
+from HLM_PV_Import.logger import logger, pv_logger
 from HLM_PV_Import.settings import CA
-from HLM_PV_Import.db_func import add_measurement
+from HLM_PV_Import.db_func import add_measurement, get_obj_id_and_create_if_not_exist
 from collections import defaultdict
 import time
 
 LOOP_TIMER = PvImportConfig.LOOP_TIMER   # The timer between each PV import loop
+EXTERNAL_PVS_UPDATE_INTERVAL = 3600
+EXTERNAL_PVS_TASK = 'External PVs'
 
 
 class PvImport:
-    def __init__(self, pv_monitors: PvMonitors, user_config: UserConfig):
+    def __init__(self, pv_monitors: PvMonitors, user_config: UserConfig, external_pvs_list: list):
         self.pv_monitors = pv_monitors
         self.config = user_config
+        self.external_pvs_list = external_pvs_list  # Configurations for PVs not part of the Helium Recovery PLC
         self.tasks = {}
         self.running = False
 
         # Initialize tasks
         for obj_id in self.config.object_ids:
             self.tasks[obj_id] = 0
+        self.tasks[EXTERNAL_PVS_TASK] = 0
 
     def start(self):
         """
@@ -29,50 +33,87 @@ class PvImport:
 
         while self.running:
             time.sleep(LOOP_TIMER)
-            for object_id in self.config.object_ids:
 
+            # Helium Recovery PLC Measurements
+            for object_id in self.config.object_ids:
                 # Check the object's next logging time in tasks, if not yet then go to next object_id
                 if self.tasks[object_id] > time.time():
                     continue
                 # If object is ready to be updated, set curr time + log period in minutes as next run, then proceed
                 self.tasks[object_id] = time.time() + (60 * self.config.logging_periods[object_id])
 
-                # Get the object's PVs, the initialize the blank measurement values dict (with None values)
+                # Get the object measurement PVs names
                 object_meas = self.config.get_entry_measurement_pvs(object_id, full_names=True)
-                mea_values = defaultdict(lambda: None)
 
-                # Iterate through the list of PVs, get the values from the PV monitor data dict, and add them to the
-                # measurement values.
-                for mea_number, pv_name in object_meas.items():
-                    # If the measurement doesn't have an assigned PV, go to the next one.
-                    if not pv_name:
-                        continue
+                # Get the measurement PV values
+                mea_values = self._get_mea_values(object_meas)
 
-                    # Add the PV value to the measurements. If the PV does not exist in the PV monitors data dict,
-                    # then skip it. This could happen because of a monitor not receiving updates from the existing PV.
-                    try:
-
-                        # If the PV data is stale, then ignore it. If Add Stale PVs setting is enabled, add it anyway.
-                        if self.pv_monitors.pv_data_is_stale(pv_name) and not CA.ADD_STALE_PVS:
-                            continue
-
-                        pv_value = self.pv_monitors.get_pv_data(pv_name)
-                        mea_values[mea_number] = pv_value
-                    except Exception as e:
-                        logger.error(e)
-                        continue
-
-                # If none of the measurement PVs values were found in the PV monitors data,
+                # If none of the measurement PVs values were found in the PV data,
                 # skip to the next object.
                 if all(value is None for value in mea_values.values()):
-                    logger.warning(f'No PV values for object with object ID {object_id}, skipping. ')
+                    logger.warning(f'No PV values for measurement of object {object_id}, skipping. ')
                     continue
 
                 # Create a new measurement with the PV values for the object
                 add_measurement(object_id=object_id, mea_values=mea_values)
+
+            # External (Non-PLC) Measurements
+
+            # Update external PV measurements only every 'EXTERNAL_PVS_UPDATE_INTERVAL' seconds
+            if self.tasks[EXTERNAL_PVS_TASK] > time.time():
+                continue
+            # noinspection PyTypeChecker
+            self.tasks[EXTERNAL_PVS_TASK] = time.time() + EXTERNAL_PVS_UPDATE_INTERVAL
+
+            for external_pvs_config in self.external_pvs_list:
+                for obj_name, mea_pvs in external_pvs_config.pv_config.items():
+                    mea_values = self._get_mea_values({f'{i+1}': pv for i, pv in enumerate(mea_pvs)},
+                                                      ignore_stale_pvs=True)
+                    if all(value is None for value in mea_values.values()):
+                        continue
+
+                    comment = f'Non-PLC PVs ({external_pvs_config.name})'
+                    obj_id = get_obj_id_and_create_if_not_exist(obj_name, external_pvs_config.objects_type, comment)
+
+                    add_measurement(object_id=obj_id, mea_values=mea_values)
 
     def stop(self):
         """
         Stop the PV Import loop if it is currently running.
         """
         self.running = False
+
+    def _get_mea_values(self, meas_pv_config: dict, ignore_stale_pvs: bool = False):
+        """
+        Iterate through the list of PVs, get the values from the PV monitor data dict, and add them to the
+        measurement values.
+
+        Args:
+            meas_pv_config (dict): The Measurement No./PV Name configuration.
+            ignore_stale_pvs (bool): Don't add stale PVs to values, no matter the CA settings.
+
+        Returns:
+            (defaultdict): The measurement values.
+        """
+        mea_values = defaultdict(lambda: None)
+        for mea_number, pv_name in meas_pv_config.items():
+            # If the measurement doesn't have an assigned PV, go to the next one.
+            if not pv_name:
+                continue
+
+            # Add the PV value to the measurements. If the PV does not exist in the PV monitors data dict,
+            # then skip it. This could happen because of a monitor not receiving updates from the existing PV.
+            try:
+
+                # If the PV data is stale, then ignore it. If Add Stale PVs setting is enabled, add it anyway.
+                # If called with 'ignore stale PVs' set to True, don't add stale PVs, no matter the CA settings.
+                if self.pv_monitors.pv_data_is_stale(pv_name) and not CA.ADD_STALE_PVS and not ignore_stale_pvs:
+                    continue
+
+                pv_value = self.pv_monitors.get_pv_data(pv_name)
+                mea_values[mea_number] = pv_value
+            except Exception as e:
+                pv_logger.warning(f'No PV data found for {e}')
+                continue
+
+        return mea_values

--- a/HLM_PV_Import/utils.py
+++ b/HLM_PV_Import/utils.py
@@ -1,0 +1,47 @@
+import collections
+import itertools
+import numbers
+import sys
+import zlib
+
+
+def ints_to_string(integers):
+    if isinstance(integers, collections.Sequence):
+        stripped = itertools.takewhile(lambda x: x != 0, integers)
+        if sys.hexversion < 0x03000000:
+            value = ''.join([chr(c) for c in stripped])
+        else:
+            value = bytes(stripped).decode()
+    elif isinstance(integers, numbers.Integral):
+        if integers == 0:
+            value = ''
+        elif sys.hexversion < 0x03000000:
+            # noinspection PyTypeChecker
+            value = chr(integers)
+        else:
+            # noinspection PyTypeChecker
+            value = bytes([integers]).decode()
+    else:
+        value = None
+
+    return value
+
+
+def dehex_and_decompress(value):
+    """
+    Decompress and dehex PV value.
+
+    Args:
+        value: Value to translate.
+
+    Returns:
+        Dehexed value.
+
+    """
+    try:
+        # If it comes as bytes then cast to string
+        value = value.decode('utf-8')
+    except AttributeError:
+        pass
+
+    return zlib.decompress(bytes.fromhex(value)).decode("utf-8")

--- a/shared/const.py
+++ b/shared/const.py
@@ -21,3 +21,4 @@ class DBClassIDs:
 
 class DBTypeIDs:
     SLD = 18
+    MERCURY_CRYOSTAT = 28


### PR DESCRIPTION
Added Mercury Cryostat PVs from various instruments to the PV Import. 
These PVs are external (non helium recovery PLC) and are currently configured directly in `HLM_PV_Import/external_pvs.py`.
