### PR TITLE
Add GCM for Gas Counters, rename SLD, GCM etc. to Modules

### DIFF
--- a/HLM_PV_Import/pv_import.py
+++ b/HLM_PV_Import/pv_import.py
@@ -53,7 +53,6 @@ class PvImport:
                 # skip to the next object.
                 if all(value is None for value in mea_values.values()):
                     logger.warning(f'No PV values for measurement of object {object_id}, skipping. ')
-
                     continue
 
                 # Create a new measurement with the PV values for the object

--- a/ServiceManager/GUI/layouts/ConfigEntry.ui
+++ b/ServiceManager/GUI/layouts/ConfigEntry.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>850</width>
-    <height>628</height>
+    <height>639</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -683,7 +683,7 @@
            <item>
             <layout class="QGridLayout" name="gridLayout_2">
              <item row="2" column="1">
-              <widget class="QLineEdit" name="obj_detail_sld_id">
+              <widget class="QLineEdit" name="obj_detail_module_id">
                <property name="font">
                 <font>
                  <pointsize>8</pointsize>
@@ -696,10 +696,10 @@
                 <enum>Qt::NoFocus</enum>
                </property>
                <property name="toolTip">
-                <string>The record ID of the Software Level Device.</string>
+                <string>The object ID of this object's module.</string>
                </property>
                <property name="whatsThis">
-                <string>The ID of the SLD. Measurements will be added to it instead of the object's ID. The object knows its measurements through the relation between itself and the SLD.</string>
+                <string>The ID of the module. Measurements will be added to the module instead of the object. The object has its measurements through the relation between itself and the module.</string>
                </property>
                <property name="styleSheet">
                 <string notr="true">background-color: #F0F0F0;</string>
@@ -710,19 +710,19 @@
               </widget>
              </item>
              <item row="2" column="0">
-              <widget class="QLabel" name="obj_detail_sld_id_lbl">
+              <widget class="QLabel" name="obj_detail_module_id_lbl">
                <property name="font">
                 <font>
                  <pointsize>9</pointsize>
                 </font>
                </property>
                <property name="text">
-                <string>SLD ID</string>
+                <string>Module ID</string>
                </property>
               </widget>
              </item>
              <item row="0" column="0" colspan="2">
-              <widget class="QLabel" name="obj_detail_sld_top_lbl">
+              <widget class="QLabel" name="obj_detail_module_top_lbl">
                <property name="enabled">
                 <bool>true</bool>
                </property>
@@ -738,7 +738,7 @@
                 </font>
                </property>
                <property name="text">
-                <string>Software Level Device</string>
+                <string>Object Modules</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignCenter</set>
@@ -746,7 +746,7 @@
               </widget>
              </item>
              <item row="1" column="1">
-              <widget class="QLineEdit" name="obj_detail_sld_name">
+              <widget class="QLineEdit" name="obj_detail_module_name">
                <property name="font">
                 <font>
                  <pointsize>8</pointsize>
@@ -759,10 +759,10 @@
                 <enum>Qt::NoFocus</enum>
                </property>
                <property name="toolTip">
-                <string>The name of the Software Level Device attached to this object, if exists.</string>
+                <string>The name of the module attached to this object, if there is one.</string>
                </property>
                <property name="whatsThis">
-                <string>The name of the Software Level Device linked to this object. A SLD &quot;stands&quot; between the object itself and its measurements, acting as a &quot;middle-man&quot;. Cryostats, vessels and gas counters require a SLD.</string>
+                <string>The name of the module linked to this object. A module &quot;stands&quot; between the object itself and its measurements, acting as a &quot;middle-man&quot;.</string>
                </property>
                <property name="styleSheet">
                 <string notr="true">background-color: #F0F0F0;</string>
@@ -773,14 +773,14 @@
               </widget>
              </item>
              <item row="1" column="0">
-              <widget class="QLabel" name="obj_detail_sld_name_lbl">
+              <widget class="QLabel" name="obj_detail_module_name_lbl">
                <property name="font">
                 <font>
                  <pointsize>9</pointsize>
                 </font>
                </property>
                <property name="text">
-                <string>SLD Name</string>
+                <string>Module Name</string>
                </property>
               </widget>
              </item>

--- a/ServiceManager/GUI/layouts/MainWindow.ui
+++ b/ServiceManager/GUI/layouts/MainWindow.ui
@@ -680,7 +680,7 @@
              </column>
              <column>
               <property name="text">
-               <string>SLD</string>
+               <string>Module</string>
               </property>
              </column>
              <column>

--- a/ServiceManager/GUI/main_window.py
+++ b/ServiceManager/GUI/main_window.py
@@ -20,8 +20,9 @@ from ServiceManager.GUI.service_path_dlg import UIServicePathDialog
 from ServiceManager.GUI.config_entry import UIConfigEntryDialog
 from ServiceManager.utilities import is_admin, set_colored_text, setup_button
 from ServiceManager.GUI.main_window_threads import ServiceLogUpdaterThread, ServiceStatusCheckThread
-from ServiceManager.db_func import db_connected, get_object_name, get_object_type, get_sld_id
+from ServiceManager.db_func import db_connected, get_object_name, get_object_type
 from shared.const import SERVICE_NAME
+from shared.utils import get_object_module
 
 EXPAND_CONFIG_TABLE_BTN = {False: ['  Expand', 'expand.svg'], True: ['  Shrink', 'shrink.svg']}
 
@@ -371,12 +372,13 @@ class UIMainWindow(QMainWindow):
 
         for entry in pv_config_data:
             object_id = entry[Settings.Service.PVConfig.OBJ]
+
             # store the entry data in a list, prepare to add to table as row
             entry_data = [
                 object_id,
                 get_object_name(object_id),
                 get_object_type(object_id),
-                get_sld_id(object_id),
+                get_object_module(object_id),
                 entry[Settings.Service.PVConfig.LOG_PERIOD],
                 *[entry[Settings.Service.PVConfig.MEAS].get(x) for x in ['1', '2', '3', '4', '5']]
             ]

--- a/ServiceManager/utilities.py
+++ b/ServiceManager/utilities.py
@@ -10,6 +10,8 @@ from ServiceManager.constants import ASSETS_PATH
 from ServiceManager.logger import manager_logger
 from caproto.sync.client import read
 
+from shared.const import DBClassIDs
+
 
 def test_pv_connection(name: str, timeout: int = 1):
     """
@@ -119,5 +121,9 @@ def setup_button(button: QPushButton, icon_name: str = None):
     button.setStyleSheet("QPushButton { text-align: left; }")
 
 
-def generate_sld_name(object_name: str, object_id: int):
-    return f'SLD "{object_name}" (ID: {object_id})'
+def generate_module_name(object_name: str, object_id: int, object_class: int):
+    if object_class in [DBClassIDs.VESSEL, DBClassIDs.CRYOSTAT]:
+        return f'SLD "{object_name}" (ID: {object_id})'
+    elif object_class == DBClassIDs.GAS_COUNTER:
+        return f'GCM "{object_name}" (ID: {object_id})'
+

--- a/shared/const.py
+++ b/shared/const.py
@@ -17,8 +17,10 @@ class DBClassIDs:
     CRYOSTAT = 4
     GAS_COUNTER = 7
     HE_LVL_MODULE = 17
+    GAS_COUNTER_MODULE = 16
 
 
 class DBTypeIDs:
-    SLD = 18
+    SLD = 18  # Software Level Device
+    GCM = 16  # Gas Counter Module
     MERCURY_CRYOSTAT = 28

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -41,6 +41,16 @@ def need_connection(func):
 
 @need_connection
 def get_object_module(object_id: int, object_class: int = None):
+    """
+    Get the module of the object with the given ID.
+
+    Args:
+        object_id (int): The object ID whose relations to check for the module.
+        object_class (int, optional): The object's class ID, if None it will be queried.
+
+    Returns:
+        (GamObject): The module object.
+    """
     if object_class is None:
         obj = GamObject.get_or_none(GamObject.ob_id == object_id)
         if obj is None:
@@ -56,16 +66,6 @@ def get_object_module(object_id: int, object_class: int = None):
 
 @need_connection
 def _get_module_object(object_id: int, module_type: int):
-    """
-    Get the module with the given type of the object with the given ID.
-
-    Args:
-        object_id (int): The object ID whose relations to check.
-        module_type (int): The type of the module to find in relations.
-
-    Returns:
-        (GamObject): The module object.
-    """
     try:
         gcm_relation = (GamObjectrelation
                         .select(GamObjectrelation.or_object_id_assigned)


### PR DESCRIPTION
#### Description
Use Gas Counter Modules (GCM) instead for SLD's for Gas Counter objects.
Renamed and categorized SLD, GCM, etc. as object "Modules" in the code and documentation.
Some minor refactoring.

#### Ticket
https://github.com/ISISNeutronMuon/HLM_PV_Import/issues/18

#### Acceptance criteria
- [ ] Update the type of all SLDs for Gas Counter objects to gas counter module default or created type (e.g. Software GC Device) of class Gas counter module.
- [x] Update the service to check for (and add measurements to) GC Software Devices instead of SLDs when the object's type is Gas Counter.
- [x] Update the manager to add GC Software Devices when creating a GC object, and replace the SLD labels in the GUI with a more general "Software Device".
- [x] Update the [documentation](https://github.com/ISISNeutronMuon/HLM_PV_Import/wiki). (Software level devices section replaced with Object Modules)
- [ ] Make sure the change is also implemented in the HLM View website (https://github.com/ISISNeutronMuon/HLM_View/issues/1).

#### Note
Used `gas counter module default` type objects for GCMs.
Database needs to be updated before deployment.
