### PR TITLE
Disable main window when dialog box is open

### DIFF
--- a/ServiceManager/GUI/about.py
+++ b/ServiceManager/GUI/about.py
@@ -9,6 +9,7 @@ class UIAbout(QDialog):
     def __init__(self):
         super(UIAbout, self).__init__()
         uic.loadUi(uifile=about_ui, baseinstance=self)
+        self.setModal(True)
 
         # Remove the "?" QWhatsThis button from the About dialog
         # noinspection PyTypeChecker

--- a/ServiceManager/GUI/ca_settings.py
+++ b/ServiceManager/GUI/ca_settings.py
@@ -13,7 +13,8 @@ class UICASettings(QDialog):
     def __init__(self):
         super(UICASettings, self).__init__()
         uic.loadUi(uifile=ca_settings_ui, baseinstance=self)
-
+        self.setModal(True)
+        
         self._settings_changed = False
 
         # region Get widgets

--- a/ServiceManager/GUI/config_entry.py
+++ b/ServiceManager/GUI/config_entry.py
@@ -15,6 +15,7 @@ class UIConfigEntryDialog(QDialog):
     def __init__(self):
         super(UIConfigEntryDialog, self).__init__()
         uic.loadUi(uifile=config_entry_ui, baseinstance=self)  # Load the UI file and its widgets
+        self.setModal(True)
 
         # region Attributes
         self.last_details_update_obj = None  # Name of object whose details were last updated and displayed

--- a/ServiceManager/GUI/db_settings.py
+++ b/ServiceManager/GUI/db_settings.py
@@ -14,6 +14,7 @@ class UIDBSettings(QDialog):
     def __init__(self):
         super(UIDBSettings, self).__init__()
         uic.loadUi(uifile=db_settings_ui, baseinstance=self)
+        self.setModal(True)
 
         # Initialize attributes for storing current settings
         self.settings_host = None   # Store the DB host from settings.ini

--- a/ServiceManager/GUI/general_settings.py
+++ b/ServiceManager/GUI/general_settings.py
@@ -10,6 +10,7 @@ class UIGeneralSettings(QDialog):
     def __init__(self):
         super(UIGeneralSettings, self).__init__()
         uic.loadUi(uifile=general_settings_ui, baseinstance=self)
+        self.setModal(True)
 
         self._settings_changed = False
 


### PR DESCRIPTION
Minor change to prevent errors from doing things while changing settings etc.

- To Review
Open service manager and open the various settings menus and the new entry menu, you shouldn't be able to start/stop the service while these are open.

- Issue
#21